### PR TITLE
Improve build instructions in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,11 +66,10 @@ You'll need:
 * [Nim](https://nim-lang.org/)
 * A C compiler (depending on your operating system, one might be already installed)
 
-Clone the repository - and you're good to go!
-To build the application, run `nimble build` & execute it with `./pax` (on Linux) or `pax.exe` (on Windows).
+Clone and `cd` into the repository - and you're good to go!\
+Run `nimble buildDev` to build the application for development, or run `nimble buildProd` to create an optimized release build.\
+Execute the program with `./pax` (on Linux) or `pax.exe` (on Windows).
 
-To create an optimized release build, add the `-d:release` flag to the build command.
-For SSL support (which may be needed when downloading mods), add the `-d:ssl` flag.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,10 @@ You'll need:
 * A C compiler (depending on your operating system, one might be already installed)
 
 Clone the repository - and you're good to go!
-To build the application, run `nimble build` & execute it with `./pax` (on Linux) or `./pax.exe` (on Windows).
+To build the application, run `nimble build` & execute it with `./pax` (on Linux) or `pax.exe` (on Windows).
+
+To create an optimized release build, add the `-d:release` flag to the build command.
+For SSL support (which may be needed when downloading mods), add the `-d:ssl` flag.
 
 ---
 


### PR DESCRIPTION
Add details for creating release builds as well as compiling with SSL support.
Also change the command for running on Windows (the ./ shouldn't be necessary)