### PR TITLE
Mark command 

### DIFF
--- a/src/cmd/add.nim
+++ b/src/cmd/add.nim
@@ -24,6 +24,7 @@ proc addDependencies(manifest: var Manifest, file: ManifestFile,
       metadata = initManifestMetadata(
         name = cfMod.name,
         explicit = false,
+        installOn = "both",
         dependencies = cfModFile.dependencies
       )
       
@@ -118,6 +119,7 @@ proc paxAdd*(input: string, noDepends: bool, strategy: string): void =
     metadata = initManifestMetadata(
       name = cfMod.name,
       explicit = true,
+      installOn = "both",
       dependencies = cfModFile.dependencies
     )
   )

--- a/src/cmd/mark.nim
+++ b/src/cmd/mark.nim
@@ -1,0 +1,33 @@
+import asyncdispatch, asyncfutures, strutils, terminal, options, os
+import common
+import ../api/cf
+import ../cli/term, ../cli/prompt
+import ../modpack/files, ../modpack/install
+import ../util/flow
+
+proc paxMark*(name: string, mark: string): void =
+  ## mark a mod 
+  requirePaxProject()
+
+  var manifest = readManifestFromDisk()
+
+  let cfMods = waitFor(fetchModsByQuery(name))
+
+  echoDebug "Locating mod.."
+  let cfModOption = manifest.promptModChoice(cfMods, selectInstalled = true)
+  if cfModOption.isNone:
+    echoError "No installed mods found for your search."
+    quit(1)
+  let cfMod = cfModOption.get()
+
+  echo ""
+  echoRoot "SELECTED MOD".dim
+  echoMod(cfMod, moreInfo = false)
+  echo ""
+
+  returnIfNot promptYN(("Are you sure you want to mark this mod as " & mark), default = true)
+
+  echoInfo "Marked ", cfMod.name.cyanFg, " as ", mark
+  # manifest.updateMod(cfMod.projectId, cfModFile.get().fileId)
+
+  manifest.writeToDisk()

--- a/src/cmd/mark.nim
+++ b/src/cmd/mark.nim
@@ -6,6 +6,14 @@ import ../modpack/files, ../modpack/install
 import ../util/flow
 
 proc paxMark*(name: string, mark: string): void =
+  const possibleMarks = @["server","client","both","explicit","implicit"]
+  if not possibleMarks.contains(mark):
+    echoError "mark must be one of:"
+    for possible in possibleMarks:
+      echo possible
+    quit(1)
+
+
   ## mark a mod 
   requirePaxProject()
 
@@ -26,6 +34,32 @@ proc paxMark*(name: string, mark: string): void =
   echo ""
 
   returnIfNot promptYN(("Are you sure you want to mark this mod as " & mark), default = true)
+
+  var createdMetadata: ManifestMetadata
+  let currentFileData = manifest.getFile(cfMod.projectId)
+
+  if @["explicit","implicit"].contains(mark):
+    createdMetadata = initManifestMetadata(
+      name = cfMod.name,
+      explicit = (mark == "explicit"),
+      installOn = currentFileData.metadata.installOn,
+      dependencies = currentFileData.metadata.dependencies
+    )
+  else:
+    createdMetadata = initManifestMetadata(
+      name = cfMod.name,
+      explicit = currentFileData.metadata.explicit,
+      installOn = mark,
+      dependencies = currentFileData.metadata.dependencies
+    )
+
+  let modToInstall = initManifestFile(
+    projectId = cfMod.projectId,
+    fileId = currentFileData.fileId,
+    metadata = createdMetadata
+  )
+  discard manifest.removeMod(cfMod.projectId)
+  manifest.installMod(modToInstall)
 
   echoInfo "Marked ", cfMod.name.cyanFg, " as ", mark
   # manifest.updateMod(cfMod.projectId, cfModFile.get().fileId)

--- a/src/cmd/mark.nim
+++ b/src/cmd/mark.nim
@@ -2,11 +2,11 @@ import asyncdispatch, asyncfutures, strutils, terminal, options, os
 import common
 import ../api/cf
 import ../cli/term, ../cli/prompt
-import ../modpack/files, ../modpack/install
+import ../modpack/files
 import ../util/flow
 
 proc paxMark*(name: string, mark: string): void =
-  ## mark a mod 
+  ## mark a mod
   requirePaxProject()
 
   var manifest = readManifestFromDisk()
@@ -28,6 +28,5 @@ proc paxMark*(name: string, mark: string): void =
   returnIfNot promptYN(("Are you sure you want to mark this mod as " & mark), default = true)
 
   echoInfo "Marked ", cfMod.name.cyanFg, " as ", mark
-  # manifest.updateMod(cfMod.projectId, cfModFile.get().fileId)
 
   manifest.writeToDisk()

--- a/src/cmd/mark.nim
+++ b/src/cmd/mark.nim
@@ -2,11 +2,11 @@ import asyncdispatch, asyncfutures, strutils, terminal, options, os
 import common
 import ../api/cf
 import ../cli/term, ../cli/prompt
-import ../modpack/files
+import ../modpack/files, ../modpack/install
 import ../util/flow
 
 proc paxMark*(name: string, mark: string): void =
-  ## mark a mod
+  ## mark a mod 
   requirePaxProject()
 
   var manifest = readManifestFromDisk()
@@ -28,5 +28,6 @@ proc paxMark*(name: string, mark: string): void =
   returnIfNot promptYN(("Are you sure you want to mark this mod as " & mark), default = true)
 
   echoInfo "Marked ", cfMod.name.cyanFg, " as ", mark
+  # manifest.updateMod(cfMod.projectId, cfModFile.get().fileId)
 
   manifest.writeToDisk()

--- a/src/cmd/remove.nim
+++ b/src/cmd/remove.nim
@@ -2,7 +2,7 @@ import asyncdispatch, asyncfutures, strutils, terminal, options, os
 import common
 import ../api/cf
 import ../cli/prompt, ../cli/term
-import ../modpack/files, ../modpack/install
+import ../modpack/files
 import ../util/flow
 
 proc removeDependencies(manifest: var Manifest, file: ManifestFile): void =

--- a/src/cmd/remove.nim
+++ b/src/cmd/remove.nim
@@ -2,7 +2,7 @@ import asyncdispatch, asyncfutures, strutils, terminal, options, os
 import common
 import ../api/cf
 import ../cli/prompt, ../cli/term
-import ../modpack/files
+import ../modpack/files, ../modpack/install
 import ../util/flow
 
 proc removeDependencies(manifest: var Manifest, file: ManifestFile): void =

--- a/src/modpack/files.nim
+++ b/src/modpack/files.nim
@@ -7,10 +7,14 @@ import ../api/cf
 export term
 
 type
+  serverOrClient* = enum
+    serverAndClient, serverOnly, clientOnly, unknown
+
   ManifestMetadata* = object
     ## Metadata for a given project in a manifest.json
     name*: string
     explicit*: bool
+    serverOrClient: serverOrClient
     dependencies*: seq[int]
 
   ManifestFile* = object
@@ -19,7 +23,6 @@ type
     projectId*: int
     fileId*: int
     metadata*: ManifestMetadata
-    
 
   Manifest* = object
     ## a project in a manifest.json.
@@ -50,12 +53,35 @@ proc initManifestMetadata*(name: string, explicit: bool, dependencies: seq[int])
   result.name = name
   result.explicit = explicit
   result.dependencies = dependencies
+  result.serverOrClient = serverAndClient
 
 proc initManifestFile*(projectId: int, fileId: int, metadata: ManifestMetadata): ManifestFile =
   ## create a new manifest fmod object.
   result.projectId = projectId
   result.fileId = fileId
   result.metadata = metadata
+
+converter toServerOrClient*(str: string): serverOrClient =
+  case str:
+    of "serverAndClient":
+      return serverAndClient
+    of "serverOnly":
+      return serverOnly
+    of "clientOnly":
+      return clientOnly
+    else:
+      return unknown
+
+converter toServerOrClient*(integer: int): serverOrClient =
+  case integer:
+    of 0:
+      return serverAndClient
+    of 1:
+      return serverOnly
+    of 2:
+      return clientOnly
+    else:
+      return unknown
 
 converter toManifestFile(json: JsonNode): ManifestFile =
   ## creates a ManifestFile from manifest json
@@ -70,6 +96,7 @@ converter toManifestFile(json: JsonNode): ManifestFile =
   else:
     result.metadata.name = json["__meta"]["name"].getStr()
     result.metadata.explicit = json["__meta"]["explicit"].getBool()
+    result.metadata.serverOrClient = json["__meta"]{"serverOrClient"}.getInt()
     result.metadata.dependencies = json["__meta"]["dependencies"].getElems().map((x) => x.getInt())
 
 converter toJson(file: ManifestFile): JsonNode {.used.} =
@@ -81,6 +108,7 @@ converter toJson(file: ManifestFile): JsonNode {.used.} =
     "__meta": {
       "name": file.metadata.name,
       "explicit": file.metadata.explicit,
+      "serverOrClient": file.metadata.serverOrClient,
       "dependencies": file.metadata.dependencies
     }
   }

--- a/src/modpack/files.nim
+++ b/src/modpack/files.nim
@@ -7,14 +7,10 @@ import ../api/cf
 export term
 
 type
-  serverOrClient* = enum
-    serverAndClient, serverOnly, clientOnly, unknown
-
   ManifestMetadata* = object
     ## Metadata for a given project in a manifest.json
     name*: string
     explicit*: bool
-    serverOrClient: serverOrClient
     dependencies*: seq[int]
 
   ManifestFile* = object
@@ -23,6 +19,7 @@ type
     projectId*: int
     fileId*: int
     metadata*: ManifestMetadata
+    
 
   Manifest* = object
     ## a project in a manifest.json.
@@ -53,35 +50,12 @@ proc initManifestMetadata*(name: string, explicit: bool, dependencies: seq[int])
   result.name = name
   result.explicit = explicit
   result.dependencies = dependencies
-  result.serverOrClient = serverAndClient
 
 proc initManifestFile*(projectId: int, fileId: int, metadata: ManifestMetadata): ManifestFile =
   ## create a new manifest fmod object.
   result.projectId = projectId
   result.fileId = fileId
   result.metadata = metadata
-
-converter toServerOrClient*(str: string): serverOrClient =
-  case str:
-    of "serverAndClient":
-      return serverAndClient
-    of "serverOnly":
-      return serverOnly
-    of "clientOnly":
-      return clientOnly
-    else:
-      return unknown
-
-converter toServerOrClient*(integer: int): serverOrClient =
-  case integer:
-    of 0:
-      return serverAndClient
-    of 1:
-      return serverOnly
-    of 2:
-      return clientOnly
-    else:
-      return unknown
 
 converter toManifestFile(json: JsonNode): ManifestFile =
   ## creates a ManifestFile from manifest json
@@ -96,7 +70,6 @@ converter toManifestFile(json: JsonNode): ManifestFile =
   else:
     result.metadata.name = json["__meta"]["name"].getStr()
     result.metadata.explicit = json["__meta"]["explicit"].getBool()
-    result.metadata.serverOrClient = json["__meta"]{"serverOrClient"}.getInt()
     result.metadata.dependencies = json["__meta"]["dependencies"].getElems().map((x) => x.getInt())
 
 converter toJson(file: ManifestFile): JsonNode {.used.} =
@@ -108,7 +81,6 @@ converter toJson(file: ManifestFile): JsonNode {.used.} =
     "__meta": {
       "name": file.metadata.name,
       "explicit": file.metadata.explicit,
-      "serverOrClient": file.metadata.serverOrClient,
       "dependencies": file.metadata.dependencies
     }
   }

--- a/src/modpack/files.nim
+++ b/src/modpack/files.nim
@@ -11,6 +11,7 @@ type
     ## Metadata for a given project in a manifest.json
     name*: string
     explicit*: bool
+    installOn*: string
     dependencies*: seq[int]
 
   ManifestFile* = object
@@ -45,10 +46,11 @@ const
   manifestFile* = joinPath(packFolder, "manifest.json")
   outputFolder* = joinPath(projectFolder, ".out/")
 
-proc initManifestMetadata*(name: string, explicit: bool, dependencies: seq[int]): ManifestMetadata =
+proc initManifestMetadata*(name: string, explicit: bool, installOn: string, dependencies: seq[int]): ManifestMetadata =
   ## create a new manifest metadata object.
   result.name = name
   result.explicit = explicit
+  result.installOn = installOn
   result.dependencies = dependencies
 
 proc initManifestFile*(projectId: int, fileId: int, metadata: ManifestMetadata): ManifestFile =
@@ -66,9 +68,11 @@ converter toManifestFile(json: JsonNode): ManifestFile =
     let cfModFile = waitFor(fetchModFile(json["projectID"].getInt(), json["fileID"].getInt()))
     result.metadata.name = cfMod.name
     result.metadata.explicit = true
+    result.metadata.installOn = "both"
     result.metadata.dependencies = cfModFile.dependencies
   else:
     result.metadata.name = json["__meta"]["name"].getStr()
+    result.metadata.installOn = json["__meta"]["installOn"].getStr()
     result.metadata.explicit = json["__meta"]["explicit"].getBool()
     result.metadata.dependencies = json["__meta"]["dependencies"].getElems().map((x) => x.getInt())
 
@@ -81,6 +85,7 @@ converter toJson(file: ManifestFile): JsonNode {.used.} =
     "__meta": {
       "name": file.metadata.name,
       "explicit": file.metadata.explicit,
+      "installOn": file.metadata.installOn,
       "dependencies": file.metadata.dependencies
     }
   }

--- a/src/pax.nim
+++ b/src/pax.nim
@@ -1,7 +1,7 @@
 import therapist
 import cli/clr, cli/prompt
 import cmd/add, cmd/expo, cmd/impo, cmd/init, cmd/list, cmd/remove, cmd/update,
-    cmd/upgrade, cmd/version
+    cmd/upgrade, cmd/version, cmd/mark
 
 let commonArgs = (
   strategy: newStringArg(@["-s", "--strategy"], choices = @["recommended",
@@ -43,6 +43,15 @@ let addCmd = (
 
 let removeCmd = (
   name: newStringArg(@["<name>"], help = "name of the mod to remove"),
+  strategy: commonArgs.strategy,
+  yes: commonArgs.yes,
+  noColor: commonArgs.noColor,
+  help: newHelpArg()
+)
+
+let markCmd = (
+  name: newStringArg(@["<name>"], help = "name of the mod to mark"),
+  mark: newStringArg(@["<mark>"], help = "marking"),
   strategy: commonArgs.strategy,
   yes: commonArgs.yes,
   noColor: commonArgs.noColor,
@@ -96,6 +105,7 @@ let spec = (
   add: newCommandArg(@["add"], addCmd, help = "add a new mod to the modpack"),
   remove: newCommandArg(@["remove"], removeCmd,
       help = "remove a mod from the modpack"),
+  mark: newCommandArg(@["mark"], markCmd, help = "mark a specific mod"),
   update: newCommandArg(@["update"], updateCmd, help = "update a specific mod"),
   upgrade: newCommandArg(@["upgrade"], upgradeCmd, help = "upgrade ALL mods"),
   version: newCommandArg(@["version"], versionCmd,
@@ -126,6 +136,8 @@ elif spec.add.seen:
       strategy = addCmd.strategy.value)
 elif spec.remove.seen:
   paxRemove(name = removeCmd.name.value, strategy = removeCmd.strategy.value)
+elif spec.mark.seen:
+  paxMark(name = markCmd.name.value, mark = markCmd.mark.value)
 elif spec.update.seen:
   paxUpdate(name = updateCmd.name.value, strategy = updateCmd.strategy.value)
 elif spec.upgrade.seen:

--- a/tests/modpack/tfiles.nim
+++ b/tests/modpack/tfiles.nim
@@ -32,6 +32,7 @@ block: # manifest mods
       initManifestMetadata(
         name = "test",
         explicit = true,
+        installOn = "both",
         dependencies = @[]
       )
     )


### PR DESCRIPTION
Implements a mark command that allows the user to tag mods as serverside, clientside or both, with both being the default assigned value. Additionally, the command allow for manually toggling mod's 'explicit' status. For example, if you install Just Enough Resources, JEI will be installed as a dependency implicitly. However, JEI is probably a mod that the user wants to be in the pack even if they later decide to remove JER, so they can manually tag JEI as explicit. 

Usage:
`pax mark <modname> <markname>`

Possible markname values:
- implicit
- explicit
- server
- client
- both

The output really needs some work, but I am unsure how to extend the current echo paradigm. 

Should close #41 